### PR TITLE
Draft: SIP for JSONSchema version

### DIFF
--- a/proposals/draft/Draft - JSONSchema Version Guidance.md
+++ b/proposals/draft/Draft - JSONSchema Version Guidance.md
@@ -21,7 +21,7 @@ We should document in the Singer Spec that Singer taps and targets expect **Draf
 
 ## Motivation
 
-As of the time of writing, the latest version of json schema is **Draft 07**. While most changes between spec drafts are backwards compatible, we should nevertheless document for users and developer which version of the spec they should expect to use for best compatibility.
+As of the time of writing, the latest version of json schema is **Draft 2020-12**. While most changes between spec drafts are backwards compatible, we should nevertheless document for users and developer which version of the spec they should expect to use for best compatibility.
 
 ### Which layer(s) of the Singer ecosystem does this proposal directly touch?
 


### PR DESCRIPTION
Provides guidance for supported and recommended version(s) of the JSON Schema Draft, as discussed in #17.

Rendered draft: https://github.com/MeltanoLabs/Singer-Working-Group/blob/10188791dec992d436d8d4a59e2c55b4790216a7/proposals/draft/Draft%20-%20JSONSchema%20Version%20Guidance.md
